### PR TITLE
Simplify Expression type

### DIFF
--- a/src/verify.zig
+++ b/src/verify.zig
@@ -511,9 +511,12 @@ const MHIterator = struct {
         // initially mandatory variables: those from the given expression
         var mandatoryVariables = TokenSet.init(allocator);
         defer mandatoryVariables.deinit();
-        for (expression) |cvToken| if (cvToken.cv == .V) {
-            _ = try mandatoryVariables.add(cvToken.token);
-        };
+        for (expression) |cvToken| {
+            if (state.meanings.get(cvToken.token)) |kv| switch (kv.value) {
+                .Variable => _ = try mandatoryVariables.add(cvToken.token),
+                else => {},
+            };
+        }
 
         var mhs = SinglyLinkedList(FELabel).init();
         var len: usize = 0;
@@ -541,9 +544,12 @@ const MHIterator = struct {
                     // the variables of the $e hypothesis are also mandatory
                     const eRule = state.meanings.get(activeHypothesis.label).?.value.Rule;
                     const eExpression = eRule.conclusion;
-                    for (eExpression) |cvToken| if (cvToken.cv == .V) {
-                        _ = try mandatoryVariables.add(cvToken.token);
-                    };
+                    for (eExpression) |cvToken| {
+                        if (state.meanings.get(cvToken.token)) |kv| switch (kv.value) {
+                            .Variable => _ = try mandatoryVariables.add(cvToken.token),
+                            else => {},
+                        };
+                    }
                 },
             }
         }

--- a/src/verify.zig
+++ b/src/verify.zig
@@ -15,7 +15,7 @@ const prove = @import("prove.zig");
 const AsRuleMeaningMap = prove.AsRuleMeaningMap;
 
 pub fn copyExpression(allocator: *Allocator, original: Expression) !Expression {
-    return try sliceCopy(CVToken, allocator, original);
+    return try sliceCopy(Token, allocator, original);
 }
 
 // TODO: move to new utils.zig?
@@ -30,14 +30,13 @@ const SinglyLinkedList = std.SinglyLinkedList;
 const FELabel = struct { label: Token, fe: enum { F, E } };
 const FELabelList = std.SegmentedList(FELabel, 0);
 
-pub const CVToken = struct { token: Token, cv: enum { C, V } };
-pub const Expression = []const CVToken;
+pub const Expression = []const Token;
 
 pub fn eqExpr(a: Expression, b: Expression) bool {
     const result = brk: {
         if (a.len != b.len) break :brk false;
         for (a) |ai, i| {
-            if (!(eq(ai.token, b[i].token) and ai.cv == b[i].cv)) break :brk false;
+            if (!eq(ai, b[i])) break :brk false;
         }
         break :brk true;
     };
@@ -53,15 +52,8 @@ pub fn eqExpr(a: Expression, b: Expression) bool {
 
 fn warnExpr(expr: Expression) void {
     var sep: []const u8 = "";
-    for (expr) |cvToken| {
-        switch (cvToken.cv) {
-            .C => {
-                std.debug.warn("{1}{0}", .{ cvToken.token, sep });
-            },
-            .V => {
-                std.debug.warn("{1}${0}", .{ cvToken.token, sep });
-            },
-        }
+    for (expr) |token| {
+        std.debug.warn("{1}{0}", .{ token, sep });
         sep = " ";
     }
 }
@@ -273,20 +265,13 @@ pub const VerifyState = struct {
 
     /// caller gets ownership of result, needs to hand back to us to be freed by our allocator
     fn expressionOf(self: *Self, tokens: TokenList) !Expression {
-        var result = try self.allocator.alloc(CVToken, tokens.count());
+        var result = try self.allocator.alloc(Token, tokens.count());
         errdefer self.allocator.free(result);
         var i: usize = 0;
         var it = @as(TokenList, tokens).iterator(0);
         while (it.next()) |pToken| : (i += 1) {
             const kv = self.meanings.get(pToken.*) orelse return Error.UnexpectedToken;
-            result[i] = .{
-                .token = pToken.*,
-                .cv = switch (kv.value) {
-                    .Constant => .C,
-                    .Variable => .V,
-                    else => return Error.UnexpectedToken,
-                },
-            };
+            result[i] = pToken.*;
         }
         return result;
     }
@@ -400,10 +385,8 @@ test "tokenlist to expression" {
     defer std.testing.allocator.free(expression);
 
     expect(expression.len == 2);
-    expect(eq(expression[0].token, "wff"));
-    expect(expression[0].cv == .C);
-    expect(eq(expression[1].token, "ph"));
-    expect(expression[1].cv == .V);
+    expect(eq(expression[0], "wff"));
+    expect(eq(expression[1], "ph"));
 }
 
 test "no duplicate variable declarations" {
@@ -429,13 +412,13 @@ test "$v in nested scope, used in $a (use-after-free reproduction)" {
     try state.addStatementsFrom("$c class setvar $. ${ $v x $. vx.cv $f setvar x $. cv $a class x $.");
     const cv: InferenceRule = state.meanings.get("cv").?.value.Rule;
     const vx_cv: Hypothesis = cv.hypotheses[0];
-    const x: Token = vx_cv.expression[1].token;
+    const x: Token = vx_cv.expression[1];
     expect(eq(x, "x"));
 
     try state.addStatementsFrom("$}");
     const cv2: InferenceRule = state.meanings.get("cv").?.value.Rule;
     const vx_cv2: Hypothesis = cv.hypotheses[0];
-    const x2: Token = vx_cv.expression[1].token;
+    const x2: Token = vx_cv.expression[1];
     expect(eq(x2, "x"));
 }
 
@@ -511,9 +494,9 @@ const MHIterator = struct {
         // initially mandatory variables: those from the given expression
         var mandatoryVariables = TokenSet.init(allocator);
         defer mandatoryVariables.deinit();
-        for (expression) |cvToken| {
-            if (state.meanings.get(cvToken.token)) |kv| switch (kv.value) {
-                .Variable => _ = try mandatoryVariables.add(cvToken.token),
+        for (expression) |token| {
+            if (state.meanings.get(token)) |kv| switch (kv.value) {
+                .Variable => _ = try mandatoryVariables.add(token),
                 else => {},
             };
         }
@@ -527,8 +510,7 @@ const MHIterator = struct {
                 .F => {
                     const fRule = state.meanings.get(activeHypothesis.label).?.value.Rule;
                     assert(fRule.conclusion.len == 2);
-                    assert(fRule.conclusion[1].cv == .V);
-                    const fVariable = fRule.conclusion[1].token;
+                    const fVariable = fRule.conclusion[1];
                     if (mandatoryVariables.contains(fVariable)) {
                         // include every $f for every mandatory variable
                         var node = try mhs.createNode(.{ .label = activeHypothesis.label, .fe = .F }, allocator);
@@ -544,9 +526,9 @@ const MHIterator = struct {
                     // the variables of the $e hypothesis are also mandatory
                     const eRule = state.meanings.get(activeHypothesis.label).?.value.Rule;
                     const eExpression = eRule.conclusion;
-                    for (eExpression) |cvToken| {
-                        if (state.meanings.get(cvToken.token)) |kv| switch (kv.value) {
-                            .Variable => _ = try mandatoryVariables.add(cvToken.token),
+                    for (eExpression) |token| {
+                        if (state.meanings.get(token)) |kv| switch (kv.value) {
+                            .Variable => _ = try mandatoryVariables.add(token),
                             else => {},
                         };
                     }
@@ -661,6 +643,6 @@ test "inference rule with $f and $e mandatory hypotheses" {
 
     const alltrueRule = state.meanings.get("alltrue").?.value.Rule;
     expect(alltrueRule.hypotheses.len == 3);
-    expect(eq(alltrueRule.hypotheses[1].expression[1].token, "ph"));
-    expect(eq(alltrueRule.conclusion[0].token, "|-"));
+    expect(eq(alltrueRule.hypotheses[1].expression[1], "ph"));
+    expect(eq(alltrueRule.conclusion[0], "|-"));
 }


### PR DESCRIPTION
It turns out constant vs variable can be looked up when finding mandatory hypotheses, instead of storing in the Expression elements.