### PR TITLE
Move 'verify set.mm' outside of 'zig build'

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           version: 0.6.0
       - run: |
-          wget --quiet https://github.com/metamath/set.mm/raw/develop/set.mm --output-document set.mm && zig build
+          wget --quiet https://github.com/metamath/set.mm/raw/develop/set.mm --output-document set.mm && zig build && time zig-cache/bin/zigmmverify
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,7 +19,3 @@ pub fn main() !void {
         return err;
     };
 }
-
-test "run main" {
-    try main();
-}


### PR DESCRIPTION
This also allows me to see (rough) execution times in GitHub actions.