### PR TITLE
Match change (improvement) in `zig fmt` behavior

### DIFF
--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,7 +1,7 @@
 usingnamespace @import("globals.zig");
 
 pub const Error = error{
-// syntax errors
+    // syntax errors
     IllegalCharacter,
     Incomplete,
     UnexpectedToken,


### PR DESCRIPTION
Very likely caused by https://github.com/ziglang/zig/pull/6194.