### PR TITLE
Zig master's std.testing.expect now can error

### DIFF
--- a/src/compose.zig
+++ b/src/compose.zig
@@ -542,44 +542,44 @@ test "count number of active $d pairs" {
     try runRuleIteratorPart(&iter, "$v a b c d e $.");
 
     try runRuleIteratorPart(&iter, "$d $.");
-    expect(iter.activeDVPairs.items.len == n + 0);
+    try expect(iter.activeDVPairs.items.len == n + 0);
     n = iter.activeDVPairs.items.len;
 
     try runRuleIteratorPart(&iter, "$d a $.");
-    expect(iter.activeDVPairs.items.len == n + 0);
+    try expect(iter.activeDVPairs.items.len == n + 0);
     n = iter.activeDVPairs.items.len;
 
     try runRuleIteratorPart(&iter, "$d a a $.");
-    expect(iter.activeDVPairs.items.len == n + 1);
+    try expect(iter.activeDVPairs.items.len == n + 1);
     n = iter.activeDVPairs.items.len;
 
     try runRuleIteratorPart(&iter, "$d a b $.");
-    expect(iter.activeDVPairs.items.len == n + 1);
+    try expect(iter.activeDVPairs.items.len == n + 1);
     n = iter.activeDVPairs.items.len;
 
     try runRuleIteratorPart(&iter, "$d a b c d e $.");
-    expect(iter.activeDVPairs.items.len == n + 10);
+    try expect(iter.activeDVPairs.items.len == n + 10);
     n = iter.activeDVPairs.items.len;
 }
 
 test "$d with constant" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c class $. $d class $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c class $. $d class $.", std.testing.allocator));
 }
 
 test "$d with undeclared token" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$d class $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$d class $.", std.testing.allocator));
 }
 
 test "use undeclared variable" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wph $f wff ph $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wph $f wff ph $.", std.testing.allocator));
 }
 
 test "use undeclared variable" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wph $f wff ph $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wph $f wff ph $.", std.testing.allocator));
 }
 
 test "use statement label as a token" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c wff ph $. wph $f wff ph $. wxx $e wph $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c wff ph $. wph $f wff ph $. wxx $e wph $.", std.testing.allocator));
 }
 
 test "simplest correct $f" {
@@ -595,24 +595,24 @@ test "tokenlist to expression" {
     defer tokens.deinit();
     try tokens.append("wff");
     try tokens.append("ph");
-    expect(eqs(tokens, &[_]Token{ "wff", "ph" }));
+    try expect(eqs(tokens, &[_]Token{ "wff", "ph" }));
 
     const expression = try iter.expressionOf(tokens);
     defer std.testing.allocator.free(expression);
 
-    expect(expression.len == 2);
-    expect(eq(expression[0].token, "wff"));
-    expect(expression[0].cv == .C);
-    expect(eq(expression[1].token, "ph"));
-    expect(expression[1].cv == .V);
+    try expect(expression.len == 2);
+    try expect(eq(expression[0].token, "wff"));
+    try expect(expression[0].cv == .C);
+    try expect(eq(expression[1].token, "ph"));
+    try expect(expression[1].cv == .V);
 }
 
 test "no duplicate variable declarations" {
-    expectError(Error.Duplicate, runRuleIterator("$c ca cb $. $v v $. cav $f ca v $. cbv $f cb v $.", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$c ca cb $. $v v $. cav $f ca v $. cbv $f cb v $.", std.testing.allocator));
 }
 
 test "no duplicate variable declarations, in nested scope (2)" {
-    expectError(Error.Duplicate, runRuleIterator("$c ca cb $. ${ $v v $. cav $f ca v $. cbv $f cb v $. $}", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$c ca cb $. ${ $v v $. cav $f ca v $. cbv $f cb v $. $}", std.testing.allocator));
 }
 
 test "duplicate variable declarations, in nested scope (2)" {
@@ -631,13 +631,13 @@ test "$v in nested scope, used in $a (use-after-free reproduction)" {
     const cv: InferenceRule = iter.meanings.get("cv").?.Rule;
     const vx_cv: Hypothesis = cv.hypotheses[0];
     const x: Token = vx_cv.expression[1].token;
-    expect(eq(x, "x"));
+    try expect(eq(x, "x"));
 
     try runRuleIteratorPart(&iter, "$}");
     const cv2: InferenceRule = iter.meanings.get("cv").?.Rule;
     const vx_cv2: Hypothesis = cv.hypotheses[0];
     const x2: Token = vx_cv.expression[1].token;
-    expect(eq(x2, "x"));
+    try expect(eq(x2, "x"));
 }
 
 test "$f in nested scope (1)" {
@@ -649,19 +649,19 @@ test "$f in nested scope (2)" {
 }
 
 test "$f using two constants" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wwff $f wff wff $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wwff $f wff wff $.", std.testing.allocator));
 }
 
 test "$f using undeclared variable" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wps $f wff ps $.", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$c wff $. wps $f wff ps $.", std.testing.allocator));
 }
 
 test "token is either constant or variable, not both" {
-    expectError(Error.Duplicate, runRuleIterator("$c wff $. $v wff $.", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$c wff $. $v wff $.", std.testing.allocator));
 }
 
 test "no constant allowed in nested scope" {
-    expectError(Error.UnexpectedToken, runRuleIterator("${ $c wff $. $}", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("${ $c wff $. $}", std.testing.allocator));
 }
 
 test "nested variable" {
@@ -669,15 +669,15 @@ test "nested variable" {
 }
 
 test "nested duplicate variable" {
-    expectError(Error.Duplicate, runRuleIterator("$v ph $. ${ $v ph $. $}", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$v ph $. ${ $v ph $. $}", std.testing.allocator));
 }
 
 test "unopened block" {
-    expectError(Error.UnexpectedToken, runRuleIterator("$}", std.testing.allocator));
+    try expectError(Error.UnexpectedToken, runRuleIterator("$}", std.testing.allocator));
 }
 
 test "unclosed block" {
-    expectError(Error.Incomplete, runRuleIterator("${", std.testing.allocator));
+    try expectError(Error.Incomplete, runRuleIterator("${", std.testing.allocator));
 }
 
 test "multiple blocks" {
@@ -685,7 +685,7 @@ test "multiple blocks" {
 }
 
 test "duplicate variable" {
-    expectError(Error.Duplicate, runRuleIterator("$v ph ps ph $.", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$v ph ps ph $.", std.testing.allocator));
 }
 
 test "single variable" {
@@ -693,7 +693,7 @@ test "single variable" {
 }
 
 test "duplicate constant" {
-    expectError(Error.Duplicate, runRuleIterator("$c wff wff $.", std.testing.allocator));
+    try expectError(Error.Duplicate, runRuleIterator("$c wff wff $.", std.testing.allocator));
 }
 
 fn tokenListOf(buffer: []const u8) !TokenList {
@@ -723,7 +723,7 @@ test "iterate over no mandatory hypotheses" {
     var it = try iter.mandatoryHypothesesOf(expression);
     defer it.deinit();
     assert(it.count() == 0);
-    expect(it.next() == null);
+    try expect(it.next() == null);
 }
 
 test "iterate over single $f hypothesis" {
@@ -739,10 +739,10 @@ test "iterate over single $f hypothesis" {
     assert(it.count() == 1);
 
     item = it.next();
-    expect(eq(item.?.label, "wph"));
-    expect(item.?.fe == .F);
+    try expect(eq(item.?.label, "wph"));
+    try expect(item.?.fe == .F);
 
-    expect(it.next() == null);
+    try expect(it.next() == null);
 }
 
 test "iterate with $e hypothesis" {
@@ -758,19 +758,19 @@ test "iterate with $e hypothesis" {
     assert(it.count() == 3);
 
     item = it.next();
-    expect(eq(item.?.label, "wta"));
-    expect(item.?.fe == .F);
+    try expect(eq(item.?.label, "wta"));
+    try expect(item.?.fe == .F);
 
     item = it.next();
-    expect(eq(item.?.label, "wph"));
-    expect(item.?.fe == .F);
+    try expect(eq(item.?.label, "wph"));
+    try expect(item.?.fe == .F);
     assert(it.count() == 1);
 
     item = it.next();
-    expect(eq(item.?.label, "hyp"));
-    expect(item.?.fe == .E);
+    try expect(eq(item.?.label, "hyp"));
+    try expect(item.?.fe == .E);
 
-    expect(it.next() == null);
+    try expect(it.next() == null);
 }
 
 test "inference rule with $f and $e mandatory hypotheses" {
@@ -781,7 +781,7 @@ test "inference rule with $f and $e mandatory hypotheses" {
     try runRuleIteratorPart(&iter, "alltrue $a |- ph $.");
 
     const alltrueRule = iter.meanings.get("alltrue").?.Rule;
-    expect(alltrueRule.hypotheses.len == 3);
-    expect(eq(alltrueRule.hypotheses[1].expression[1].token, "ph"));
-    expect(eq(alltrueRule.conclusion[0].token, "|-"));
+    try expect(alltrueRule.hypotheses.len == 3);
+    try expect(eq(alltrueRule.hypotheses[1].expression[1].token, "ph"));
+    try expect(eq(alltrueRule.conclusion[0].token, "|-"));
 }

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -213,7 +213,7 @@ const TestFS = alltests.TestFS;
 
 fn forNext(statements: *StatementIterator, f: anytype) !void {
     const s = try statements.next();
-    _ = f.do(s);
+    _ = try f.do(s);
     s.?.deinit(std.testing.allocator);
 }
 
@@ -229,12 +229,12 @@ test "parse constant declaration from include file" {
 
     var statements = StatementIterator.init(std.testing.allocator, testFS.tmpDir.dir, "$[ constants.mm $]");
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(eqs(s.?.C.constants, &[_]Token{ "wff", "|-" }));
+        fn do(s: anytype) !void {
+            try expect(eqs(s.?.C.constants, &[_]Token{ "wff", "|-" }));
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse file only including empty include file" {
@@ -243,8 +243,8 @@ test "parse file only including empty include file" {
     try testFS.writeFile("empty.mm", "");
 
     var statements = StatementIterator.init(std.testing.allocator, testFS.tmpDir.dir, "$[ empty.mm $]");
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "include non-existing file" {
@@ -252,217 +252,217 @@ test "include non-existing file" {
     defer testFS.deinit();
 
     var statements = StatementIterator.init(std.testing.allocator, testFS.tmpDir.dir, "$[ nonexisting.mm $]");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IncorrectFileName);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IncorrectFileName);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "include without file name" {
     var statements = _StatementIterator_init("$[ $]");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IncorrectFileName);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IncorrectFileName);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$c with label" {
     var statements = _StatementIterator_init("c $c T $.");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(s != null);
+        fn do(s: anytype) !void {
+            try expect(s != null);
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$v with label" {
     var statements = _StatementIterator_init("v $v a $.");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(s != null);
+        fn do(s: anytype) !void {
+            try expect(s != null);
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$f without label" {
     var statements = _StatementIterator_init("$f");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.MissingLabel);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.MissingLabel);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$e without label" {
     var statements = _StatementIterator_init("$e");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.MissingLabel);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.MissingLabel);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$d with label" {
     var statements = _StatementIterator_init("dxy $d x y $.");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(s != null);
+        fn do(s: anytype) !void {
+            try expect(s != null);
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$a without label" {
     var statements = _StatementIterator_init("$a");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.MissingLabel);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.MissingLabel);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$p without label" {
     var statements = _StatementIterator_init("$p");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.MissingLabel);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.MissingLabel);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "${ with label" {
     var statements = _StatementIterator_init("block ${");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(s != null);
+        fn do(s: anytype) !void {
+            try expect(s != null);
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "$} with label" {
     var statements = _StatementIterator_init("endblock $}");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(s != null);
+        fn do(s: anytype) !void {
+            try expect(s != null);
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "unknown statement type (token skipped)" {
     var statements = _StatementIterator_init("x $x");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "too short $f statement" {
     var statements = _StatementIterator_init("w $f wff $.");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.Incomplete);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.Incomplete);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "`$xy` token after label" {
     var statements = _StatementIterator_init("$xy");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "`$xy` token after label" {
     var statements = _StatementIterator_init("aLabel $xy");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "`$` token without label" {
     var statements = _StatementIterator_init("$");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "`$` token after label" {
     var statements = _StatementIterator_init("aLabel $");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "non-$ token after label" {
     var statements = _StatementIterator_init("aLabel nonCommand");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse $p declaration" {
     var statements = _StatementIterator_init("idwffph $p wff ph $= ? $.");
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(eqs(s.?.P.tokens, &[_]Token{ "wff", "ph" }));
-            expect(eqs(s.?.P.proof, &[_]Token{"?"}));
+        fn do(s: anytype) !void {
+            try expect(eqs(s.?.P.tokens, &[_]Token{ "wff", "ph" }));
+            try expect(eqs(s.?.P.proof, &[_]Token{"?"}));
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse $f declaration" {
     var statements = _StatementIterator_init("wph $f wff ph $.");
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(eq(s.?.F.label, "wph"));
-            expect(eqs(s.?.F.tokens, &[_]Token{ "wff", "ph" }));
+        fn do(s: anytype) !void {
+            try expect(eq(s.?.F.label, "wph"));
+            try expect(eqs(s.?.F.tokens, &[_]Token{ "wff", "ph" }));
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "check error for label on $d" {
     var statements = _StatementIterator_init("xfreeinA $d A x $.");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.UnexpectedLabel);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.UnexpectedLabel);
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(eqs(s.?.D.variables, &[_]Token{ "A", "x" }));
+        fn do(s: anytype) !void {
+            try expect(eqs(s.?.D.variables, &[_]Token{ "A", "x" }));
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "check error for unknown command" {
     var statements = _StatementIterator_init("$Q");
-    if (statements.next()) |_| unreachable else |err| expect(err == Error.IllegalToken);
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    if (statements.next()) |_| unreachable else |err| try expect(err == Error.IllegalToken);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse constant declaration" {
     var statements = _StatementIterator_init("$c wff |- $.");
     _ = try forNext(&statements, struct {
-        fn do(s: anytype) void {
-            expect(eqs(s.?.C.constants, &[_]Token{ "wff", "|-" }));
+        fn do(s: anytype) !void {
+            try expect(eqs(s.?.C.constants, &[_]Token{ "wff", "|-" }));
         }
     });
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse comment, also including $[" {
     var statements = _StatementIterator_init("$( a $[ b.mm $] c $)");
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }
 
 test "parse empty file" {
     var statements = _StatementIterator_init("");
-    expect((try statements.next()) == null);
-    expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
+    try expect((try statements.next()) == null);
 }

--- a/src/prove.zig
+++ b/src/prove.zig
@@ -257,23 +257,23 @@ test "simple substitution" {
     const expected = &[_]compose.CVToken{ .{ .token = "class", .cv = .C }, .{ .token = "y", .cv = .V } };
     const actual = try substitute(original, substitution, std.testing.allocator);
     defer std.testing.allocator.free(actual);
-    expect(eqExpr(actual, expected));
+    try expect(eqExpr(actual, expected));
 }
 
 test "compare equal expressions" {
     const a = &[_]compose.CVToken{ .{ .token = "class", .cv = .C }, .{ .token = "x", .cv = .V } };
     const b = &[_]compose.CVToken{ .{ .token = "class", .cv = .C }, .{ .token = "x", .cv = .V } };
-    expect(eqExpr(a, b));
+    try expect(eqExpr(a, b));
 }
 
 test "compare unequal expressions" {
     const a = &[_]compose.CVToken{ .{ .token = "a", .cv = .C }, .{ .token = "x", .cv = .V } };
     const b = &[_]compose.CVToken{ .{ .token = "b", .cv = .C }, .{ .token = "x", .cv = .V } };
-    expect(!eqExpr(a, b));
+    try expect(!eqExpr(a, b));
 }
 
 test "compare unequal expressions, constant vs variable" {
     const a = &[_]compose.CVToken{ .{ .token = "class", .cv = .C }, .{ .token = "x", .cv = .V } };
     const b = &[_]compose.CVToken{ .{ .token = "class", .cv = .C }, .{ .token = "x", .cv = .C } };
-    expect(!eqExpr(a, b));
+    try expect(!eqExpr(a, b));
 }

--- a/src/tokenize.zig
+++ b/src/tokenize.zig
@@ -105,70 +105,70 @@ const expect = std.testing.expect;
 
 test "tokenizer on empty buffer" {
     var tokens = TokenIterator{ .buffer = "" };
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer on whitespace buffer" {
     var tokens = TokenIterator{ .buffer = "  \t " };
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer with whitespace at start" {
     var tokens = TokenIterator{ .buffer = " $d $." };
-    expect(eq((try tokens.next()).?, "$d"));
-    expect(eq((try tokens.next()).?, "$."));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$d"));
+    try expect(eq((try tokens.next()).?, "$."));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer with whitespace at end" {
     var tokens = TokenIterator{ .buffer = "$d $. " };
-    expect(eq((try tokens.next()).?, "$d"));
-    expect(eq((try tokens.next()).?, "$."));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$d"));
+    try expect(eq((try tokens.next()).?, "$."));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer with skipped illegal 'low' character" {
     var tokens = TokenIterator{ .buffer = "$d\x03$." };
-    expect(eq((try tokens.next()).?, "$d"));
-    if (tokens.next()) |_| unreachable else |err| expect(err == Error.IllegalCharacter);
-    expect(eq((try tokens.next()).?, "$."));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$d"));
+    if (tokens.next()) |_| unreachable else |err| try expect(err == Error.IllegalCharacter);
+    try expect(eq((try tokens.next()).?, "$."));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer with skipped illegal 'high' character" {
     var tokens = TokenIterator{ .buffer = "$( a\x7fc $)" };
-    expect(eq((try tokens.next()).?, "$("));
-    expect(eq((try tokens.next()).?, "a"));
-    if (tokens.next()) |_| unreachable else |err| expect(err == Error.IllegalCharacter);
-    expect(eq((try tokens.next()).?, "c"));
-    expect(eq((try tokens.next()).?, "$)"));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$("));
+    try expect(eq((try tokens.next()).?, "a"));
+    if (tokens.next()) |_| unreachable else |err| try expect(err == Error.IllegalCharacter);
+    try expect(eq((try tokens.next()).?, "c"));
+    try expect(eq((try tokens.next()).?, "$)"));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer" {
     var tokens = TokenIterator{ .buffer = "$c wff $." };
-    expect(eq((try tokens.next()).?, "$c"));
-    expect(eq((try tokens.next()).?, "wff"));
-    expect(eq((try tokens.next()).?, "$."));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$c"));
+    try expect(eq((try tokens.next()).?, "wff"));
+    try expect(eq((try tokens.next()).?, "$."));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }
 
 test "tokenizer comment without newline" {
     var tokens = TokenIterator{ .buffer = "$( a b c $)\n$c $." };
-    expect(eq((try tokens.next()).?, "$("));
-    expect(eq((try tokens.next()).?, "a"));
-    expect(eq((try tokens.next()).?, "b"));
-    expect(eq((try tokens.next()).?, "c"));
-    expect(eq((try tokens.next()).?, "$)"));
-    expect(eq((try tokens.next()).?, "$c"));
-    expect(eq((try tokens.next()).?, "$."));
-    expect((try tokens.next()) == null);
-    expect((try tokens.next()) == null);
+    try expect(eq((try tokens.next()).?, "$("));
+    try expect(eq((try tokens.next()).?, "a"));
+    try expect(eq((try tokens.next()).?, "b"));
+    try expect(eq((try tokens.next()).?, "c"));
+    try expect(eq((try tokens.next()).?, "$)"));
+    try expect(eq((try tokens.next()).?, "$c"));
+    try expect(eq((try tokens.next()).?, "$."));
+    try expect((try tokens.next()) == null);
+    try expect((try tokens.next()) == null);
 }

--- a/src/verify.zig
+++ b/src/verify.zig
@@ -103,7 +103,7 @@ fn _verifyBuffer(buffer: []const u8) !void {
 }
 
 test "proof with $d violation" {
-    expectError(Error.DVRMissing, _verifyBuffer(
+    try expectError(Error.DVRMissing, _verifyBuffer(
         \\$c wff |- $.
         \\$v P Q R $.
         \\wp $f wff P $.


### PR DESCRIPTION
...so we have to change with it to this uglier syntax.

This is needed because of a change in Zig master
from around May 10, 2021.