### PR TITLE
Fix 'unused' errors introduced found via Zig 0.9.0

### DIFF
--- a/src/compose.zig
+++ b/src/compose.zig
@@ -198,13 +198,13 @@ pub const RuleIterator = struct {
                 if (self.currentScopeDiff) |_| return Error.UnexpectedToken; // $c inside ${ $}
                 for (cStatement.constants.items) |constant| {
                     if (self.meanings.get(constant)) |_| return Error.Duplicate;
-                    const kv = try self.meanings.put(constant, MeaningType.Constant);
+                    _ = try self.meanings.put(constant, MeaningType.Constant);
                 }
             },
             .V => |vStatement| {
                 for (vStatement.variables.items) |variable| {
                     if (self.meanings.get(variable)) |_| return Error.Duplicate;
-                    const kv = try self.meanings.put(variable, Meaning{ .Variable = .{ .usedInFStatement = false } });
+                    _ = try self.meanings.put(variable, Meaning{ .Variable = .{ .usedInFStatement = false } });
                     if (self.currentScopeDiff) |scopeDiff| {
                         _ = try scopeDiff.activeTokens.add(variable); // this $v will become inactive at the next $}
                     }
@@ -522,7 +522,7 @@ fn runRuleIterator(buffer: []const u8, allocator: *Allocator) !void {
 fn runRuleIteratorPart(iter: *RuleIterator, buffer: []const u8) !void {
     const unused_root_dir = undefined; // no file access done in this test
     try iter.addStatementsFrom(unused_root_dir, buffer);
-    while (try iter.next()) |*item| {}
+    while (try iter.next()) |*_| {}
 }
 
 test "active DVR (found a memory leak)" {
@@ -634,8 +634,8 @@ test "$v in nested scope, used in $a (use-after-free reproduction)" {
     try expect(eq(x, "x"));
 
     try runRuleIteratorPart(&iter, "$}");
-    const cv2: InferenceRule = iter.meanings.get("cv").?.Rule;
-    const vx_cv2: Hypothesis = cv.hypotheses[0];
+    _ = iter.meanings.get("cv").?.Rule;
+    _ = cv.hypotheses[0];
     const x2: Token = vx_cv.expression[1].token;
     try expect(eq(x2, "x"));
 }

--- a/src/tokenize.zig
+++ b/src/tokenize.zig
@@ -57,7 +57,6 @@ pub const TokenIterator = struct {
         // invariant: self.buffer[i..j] is the current token so far
         while (true) {
             // where are we?
-            var optError: ?Error = null;
             const atEnd = (j >= self.buffer.len);
             var afterToken = true;
             if (!atEnd) {

--- a/src/verify.zig
+++ b/src/verify.zig
@@ -27,10 +27,6 @@ pub fn verifyFile(allocator: *Allocator, dir: std.fs.Dir, mm_file_name: []const 
     var iter = try RuleIterator.init(allocator);
     defer iter.deinit();
 
-    var frameArena = std.heap.ArenaAllocator.init(iter.allocator);
-    defer frameArena.deinit();
-    const frameAllocator = &frameArena.allocator;
-
     var nr_proofs: u64 = 0;
     defer std.debug.warn("\nFound {0} $p statements so far.\n", .{nr_proofs});
 
@@ -41,7 +37,6 @@ pub fn verifyFile(allocator: *Allocator, dir: std.fs.Dir, mm_file_name: []const 
             nr_proofs += 1;
             const rule = item.rule;
             std.event.Loop.startCpuBoundOperation();
-            const frame = try frameAllocator.create(@Frame(verifyProofConclusion));
             try verifyProofConclusion(&iter, item.label, proof, rule.hypotheses, .{
                 .expression = rule.conclusion,
                 .dvPairs = rule.activeDVPairs,
@@ -56,8 +51,8 @@ fn verifyProofConclusion(iter: *RuleIterator, label: []const u8, proof: TokenLis
     expression: Expression,
     dvPairs: []DVPair,
 }) anyerror!void {
-    // std.debug.warn("\nstarting to verify proof of {0s}.\n", .{label});
-    // defer std.debug.warn("end of verify proof of {0s}.\n", .{label});
+    std.log.debug("starting to verify proof of {s}.", .{label});
+    defer std.log.debug("end of verify proof of {s}.", .{label});
     var result = try prove.runProof(proof, hypotheses, iter, iter.allocator);
     defer result.deinit(iter.allocator);
 


### PR DESCRIPTION
This backports zig-master #50 to the zig-0.8.x branch.