### PR TITLE
Remove `usingnamespace` after Zig 0.9.0 change

### DIFF
--- a/src/alltests.zig
+++ b/src/alltests.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 pub const TestFS = struct {
     tmpDir: std.testing.TmpDir = undefined,

--- a/src/compose.zig
+++ b/src/compose.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const errors = @import("errors.zig");
 const Error = errors.Error;

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 pub const Error = error{
     // syntax errors

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -1,5 +1,0 @@
-pub const std = @import("std");
-pub const Allocator = std.mem.Allocator;
-pub const assert = std.debug.assert;
-
-pub const void_value: void = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const verify = @import("verify.zig");
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const errors = @import("errors.zig");
 const Error = errors.Error;

--- a/src/prove.zig
+++ b/src/prove.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const ArrayList = std.ArrayList;
 

--- a/src/read.zig
+++ b/src/read.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const errors = @import("errors.zig");
 const Error = errors.Error;

--- a/src/tokenize.zig
+++ b/src/tokenize.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const errors = @import("errors.zig");
 const Error = errors.Error;
@@ -19,7 +21,7 @@ pub const TokenSet = struct {
 
     pub fn add(self: *Self, token: Token) !bool {
         if (self.map.contains(token)) return true; // already present
-        try self.map.put(token, void_value);
+        try self.map.put(token, undefined);
         return false;
     }
 

--- a/src/verify.zig
+++ b/src/verify.zig
@@ -1,4 +1,6 @@
-usingnamespace @import("globals.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const errors = @import("errors.zig");
 const Error = errors.Error;


### PR DESCRIPTION
Trigger was https://github.com/ziglang/zig/issues/9629.