### PR TITLE
Make compile again with Zig almost-0.9.0

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,7 @@ const verify = @import("verify.zig");
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
-    const allocator = &arena.allocator;
+    const allocator = arena.child_allocator;
 
     const fileName = fileName: {
         var argIter = std.process.args();

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -28,7 +28,7 @@ pub const Statement = union(StatementType) {
     BlockOpen,
     BlockClose: struct {},
 
-    pub fn deinit(self: *Statement, allocator: *Allocator) void {
+    pub fn deinit(self: *Statement, allocator: Allocator) void {
         switch (self.*) {
             .C => self.*.C.constants.deinit(),
             .V => self.*.V.variables.deinit(),
@@ -45,7 +45,7 @@ pub const Statement = union(StatementType) {
         allocator.destroy(self);
     }
 
-    pub fn deinitLeavingProof(self: *Statement, allocator: *Allocator) TokenList {
+    pub fn deinitLeavingProof(self: *Statement, allocator: Allocator) TokenList {
         defer allocator.destroy(self);
         self.*.P.tokens.deinit();
         return self.*.P.proof;
@@ -53,13 +53,13 @@ pub const Statement = union(StatementType) {
 };
 
 pub const StatementIterator = struct {
-    allocator: *Allocator,
+    allocator: Allocator,
     dir: std.fs.Dir,
     tokens: TokenIterator,
     optStatement: ?*Statement = null,
     nestedIterator: ?*StatementIterator = null,
 
-    pub fn init(allocator: *Allocator, dir: std.fs.Dir, buffer: []const u8) StatementIterator {
+    pub fn init(allocator: Allocator, dir: std.fs.Dir, buffer: []const u8) StatementIterator {
         return StatementIterator{ .allocator = allocator, .dir = dir, .tokens = TokenIterator{ .buffer = buffer } };
     }
 

--- a/src/read.zig
+++ b/src/read.zig
@@ -6,7 +6,7 @@ const errors = @import("errors.zig");
 const Error = errors.Error;
 
 /// caller owns the result, which was allocated with the provided allocator
-pub fn readBuffer(allocator: *Allocator, dir: std.fs.Dir, file_name: []const u8) ![]const u8 {
+pub fn readBuffer(allocator: Allocator, dir: std.fs.Dir, file_name: []const u8) ![]const u8 {
     const file = dir.openFile(file_name, .{}) catch return Error.IncorrectFileName;
     defer file.close();
     const size = (try file.stat()).size;

--- a/src/tokenize.zig
+++ b/src/tokenize.zig
@@ -11,7 +11,7 @@ pub const TokenSet = struct {
     const Self = @This();
     map: TokenMap(void),
 
-    pub fn init(allocator: *Allocator) Self {
+    pub fn init(allocator: Allocator) Self {
         return Self{ .map = TokenMap(void).init(allocator) };
     }
 


### PR DESCRIPTION
`*Allocator` is now `Allocator`, and
a wrapped Allocator is by convention obtained via `.allocator()`.

`std.debug.warn` must be replaced
(noting that `zig test` considers `std.log.err` a test failure).