### PR TITLE
Update after ArgIterator.nextPosix() removal

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -11,8 +11,8 @@ pub fn main() !void {
 
     const fileName = fileName: {
         var argIter = std.process.args();
-        _ = argIter.nextPosix().?; // skip command name, is always present
-        break :fileName (argIter.nextPosix() orelse return error.SingleCommandLineArgumentExpected);
+        _ = argIter.next().?; // skip command name, is always present
+        break :fileName (argIter.next() orelse return error.SingleCommandLineArgumentExpected);
     };
 
     _ = verify.verifyFile(allocator, std.fs.cwd(), fileName) catch |err| {


### PR DESCRIPTION
Adapt to the change in ziglang/zig#4833.
Now using allocator-based parsing,
since that should be cross-platform,
and it works on Linux and Windows at least.